### PR TITLE
use type deduction

### DIFF
--- a/wano/menuitem.cpp
+++ b/wano/menuitem.cpp
@@ -9,7 +9,7 @@ namespace wano {
 	}
 
 	void MenuItem::draw(Window* menu) {
-		bool isUnderlined = false;
+		auto isUnderlined = false;
 		for (auto c : text) {
 			if (c == '&') {
 				isUnderlined = true;


### PR DESCRIPTION
Using auto is consistent with best practices for modern c++.
