### PR TITLE
Fixed typo in variable type

### DIFF
--- a/wano/document.cpp
+++ b/wano/document.cpp
@@ -33,7 +33,7 @@ namespace wano {
 	}
 
 	coord Document::cursMove(int x, int y) {
-		bool changedY = false;
+		auto changedY = false;
 		// Don't bother doing operations on unchanged coordinates
 		if (y != curs.y) {
 			changedY = true;


### PR DESCRIPTION
Be consistent with modern c++ best practices.
