### PR TITLE
Replace define with const

### DIFF
--- a/wano/textarea.h
+++ b/wano/textarea.h
@@ -5,7 +5,7 @@
 #include "document.h"
 
 // TODO: Normally the size of the textarea
-#define PAGE_SIZE 10
+const auto PAGE_SIZE = 10;
 
 namespace wano {
 	class TextArea : public curses::Window {


### PR DESCRIPTION
To be consistent with best practices, prefer const over preprocessor for program constants so they are type checked, and other things.
